### PR TITLE
Change prefix and prefix_topic for RB-WATCHER

### DIFF
--- a/robots/rbwatcher_std.urdf.xacro
+++ b/robots/rbwatcher_std.urdf.xacro
@@ -82,14 +82,14 @@
 
 		<!-- PTZ camera -->
 		<xacro:unless value="${leika}">
-			<xacro:sensor_link_750_nh prefix="${prefix}ptz_camera" parent="${prefix}base_link" fps="15.0">
+			<xacro:sensor_link_750_nh prefix="${prefix}top_ptz_camera" prefix_topic="top_ptz_camera" parent="${prefix}base_link" fps="15.0">
 				<origin xyz="-0.11808 0 0.55429" rpy="0 0 0"/>
 			</xacro:sensor_link_750_nh>
 		</xacro:unless>
 		
 		<!-- Leika Laser -->
 		<xacro:if value="${leika}">
-			<xacro:sensor_blk_arc prefix="${prefix}ptz_camera" parent="${prefix}base_link">
+			<xacro:sensor_blk_arc prefix="${prefix}top_ptz_camera" parent="${prefix}base_link">
 				<origin xyz="-0.11808 0 0.65" rpy="0 0 0"/>
 			</xacro:sensor_blk_arc>
 		</xacro:if>


### PR DESCRIPTION
This PR aims to standarize the naming for the ptz camera, that has to include the position of the camera on the robot, in this case will be "top_ptz_camera"