### PR TITLE
fix: Sets real Z for UR base in RB-KAIROS+

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robotnik_description</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   
   <description>URDF description for Robotnik robots</description>
 

--- a/robots/rbkairos/rbkairos_plus.urdf.xacro
+++ b/robots/rbkairos/rbkairos_plus.urdf.xacro
@@ -73,7 +73,7 @@
       physical_parameters_file="$(arg physical_params)"
       visual_parameters_file="$(arg visual_params)"
       sim_gazebo="$(arg gazebo_classic)">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <origin xyz="0 0 0.56362" rpy="0 0 0"/>
   </xacro:ur_robot>
 
 


### PR DESCRIPTION
This pull request includes a change to the `robots/rbkairos/rbkairos_plus.urdf.xacro` file to adjust the origin position of a robot component.

* [`robots/rbkairos/rbkairos_plus.urdf.xacro`](diffhunk://#diff-7818560383ee4419083e5c6afd9ff63b2af5134db93737aa924454ddd3f4bed6L76-R76): Modified the `origin` tag to change the `xyz` attribute from `"0 0 0"` to `"0 0 0.56362"`.