### PR TITLE
fix: Sets real Z for UR in rbkairos plus model

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robotnik_description</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   
   <description>URDF description for Robotnik robots</description>
 

--- a/robots/rbkairos/rbkairos_plus.urdf.xacro
+++ b/robots/rbkairos/rbkairos_plus.urdf.xacro
@@ -62,7 +62,7 @@
       visual_parameters_file="$(arg visual_params)"
       sim_gazebo="$(arg gazebo_classic)"
       sim_ignition="$(arg gazebo_ignition)">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <origin xyz="0 0 0.56362" rpy="0 0 0"/>
   </xacro:ur_robot>
 
 


### PR DESCRIPTION
This pull request includes a small change to the `robots/rbkairos/rbkairos_plus.urdf.xacro` file. The change modifies the `xyz` coordinates of the `origin` element to adjust the position of the robot.