### PR TITLE
Feat/jazzy/low performance arg 4 plugins

### DIFF
--- a/launch/robot_description.launch.py
+++ b/launch/robot_description.launch.py
@@ -82,6 +82,16 @@ def generate_launch_description():
         environment='GAZEBO_IGNITION_SIMULATION',
     )
     add_to_launcher.add_arg(arg)
+    
+    arg = ExtendedArgument(
+        name='low_performance_simulation',
+        description='Enable low performance simulation (for not powerful computers)',
+        default_value="false",
+        use_env=True,
+        environment='LOW_PERFORMANCE_SIMULATION',
+    )
+    
+    add_to_launcher.add_arg(arg)
 
     arg = ExtendedArgument(
         name='frame_prefix',
@@ -102,6 +112,7 @@ def generate_launch_description():
             " namespace:=",params["namespace"],
             " prefix:=",params["frame_prefix"],
             " gazebo_ignition:=", params["gazebo_ignition"],
+            " low_performance_simulation:=", params["low_performance_simulation"],
         ]
     )
     robot_description_param = ParameterValue(robot_description_content, value_type=str)

--- a/robots/rb1/rb1.urdf.xacro
+++ b/robots/rb1/rb1.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-1 -->
   <xacro:rb1

--- a/robots/rbfiqus/rbfiqus.urdf.xacro
+++ b/robots/rbfiqus/rbfiqus.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-VOGUI -->
   <xacro:rbfiqus

--- a/robots/rbkairos/rbkairos.urdf.xacro
+++ b/robots/rbkairos/rbkairos.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-KAIROS -->
   <xacro:rbkairos

--- a/robots/rbkairos/rbkairos_plus.urdf.xacro
+++ b/robots/rbkairos/rbkairos_plus.urdf.xacro
@@ -20,6 +20,9 @@
     name="gazebo_ignition"
     default="false" />
   <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
+  <xacro:arg
     name="ur_type"
     default="ur5e" />
 

--- a/robots/rbrobout/rbrobout.urdf.xacro
+++ b/robots/rbrobout/rbrobout.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-ROBOUT -->
   <xacro:rbrobout

--- a/robots/rbrobout/rbrobout_plus.urdf.xacro
+++ b/robots/rbrobout/rbrobout_plus.urdf.xacro
@@ -24,6 +24,9 @@
     name="gazebo_ignition"
     default="false" />
   <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
+  <xacro:arg
     name="ur_type"
     default="ur5e" />
 

--- a/robots/rbsummit/rbsummit.urdf.xacro
+++ b/robots/rbsummit/rbsummit.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-SUMMIT -->
   <xacro:rbsummit

--- a/robots/rbsummit_steel/rbsummit_steel.urdf.xacro
+++ b/robots/rbsummit_steel/rbsummit_steel.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-SUMMIT-STEEL -->
   <xacro:rbsummit_steel

--- a/robots/rbtheron/rbtheron.urdf.xacro
+++ b/robots/rbtheron/rbtheron.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-THERON -->
   <xacro:rbtheron

--- a/robots/rbtheron/rbtheron_plus.urdf.xacro
+++ b/robots/rbtheron/rbtheron_plus.urdf.xacro
@@ -22,6 +22,9 @@
     name="gazebo_ignition"
     default="false" />
   <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
+  <xacro:arg
     name="ur_type"
     default="ur5e" />
 

--- a/robots/rbvogui/rbvogui.urdf.xacro
+++ b/robots/rbvogui/rbvogui.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-VOGUI -->
   <xacro:rbvogui

--- a/robots/rbvogui/rbvogui_plus.urdf.xacro
+++ b/robots/rbvogui/rbvogui_plus.urdf.xacro
@@ -20,6 +20,9 @@
     name="gazebo_ignition"
     default="false" />
   <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
+  <xacro:arg
     name="ur_type"
     default="ur5e" />
 

--- a/robots/rbwatcher/rbwatcher.urdf.xacro
+++ b/robots/rbwatcher/rbwatcher.urdf.xacro
@@ -17,6 +17,9 @@
   <xacro:arg
     name="gazebo_ignition"
     default="false" />
+  <xacro:arg
+    name="low_performance_simulation"
+    default="false" />
 
   <!-- RB-WATCHER -->
   <xacro:rbwatcher
@@ -41,7 +44,8 @@
     parent="$(arg prefix)base_link"
     node_namespace="$(arg namespace)"
     node_name="top_lidar"
-    gazebo_ignition="$(arg gazebo_ignition)">
+    gazebo_ignition="$(arg gazebo_ignition)"
+    low_performance="$(arg low_performance_simulation)">
     <origin
       xyz="-0.11924 0 0.38609"
       rpy="0 0 0" />
@@ -53,7 +57,8 @@
     parent="$(arg prefix)base_link"
     node_namespace="$(arg namespace)"
     node_name="front_camera"
-    gazebo_ignition="$(arg gazebo_ignition)">
+    gazebo_ignition="$(arg gazebo_ignition)"
+    low_performance="$(arg low_performance_simulation)">
     <origin
       xyz="0.29881 0.0 0.15243"
       rpy="0 0 0" />
@@ -64,7 +69,8 @@
     parent="$(arg prefix)base_link"
     node_namespace="$(arg namespace)"
     node_name="top_ptz_camera"
-    gazebo_ignition="$(arg gazebo_ignition)">
+    gazebo_ignition="$(arg gazebo_ignition)"
+    low_performance="$(arg low_performance_simulation)">
     <origin
       xyz="-0.11808 0 0.55429"
       rpy="0 0 0" />


### PR DESCRIPTION
This pull request introduces support for a new simulation mode aimed at improving performance on less powerful computers. The main change is the addition of a `low_performance_simulation` argument across all robot launch and description files, allowing users to enable a low-performance simulation via an environment variable or launch argument. Additionally, the argument is now passed through the launch pipeline and integrated into the robot URDF/Xacro files, with specific usage in the `rbwatcher` robot sensors.

**Launch system improvements:**

* Added a new `low_performance_simulation` argument to `launch/robot_description.launch.py`, which can be set via the environment variable `LOW_PERFORMANCE_SIMULATION`. This enables users to toggle low-performance simulation mode easily.
* Updated the launch pipeline to pass the `low_performance_simulation` parameter to robot description files.

**Robot URDF/Xacro updates:**

* Added the `low_performance_simulation` argument (with default value "false") to all robot URDF/Xacro files, including RB-1, RB-KAIROS, RB-VOGUI, RB-SUMMIT, RB-THERON, RB-ROBUT, RB-WATCHER, and their respective "plus" variants. [[1]](diffhunk://#diff-428bc32484ce3f53597ca9d786b6f60b3f85380235b55ba183eced4628f747ceR20-R22) [[2]](diffhunk://#diff-09b567a970ccde46b9e68a4c90cfb1144f935cad9bbaf19607235995b2ef7998R20-R22) [[3]](diffhunk://#diff-ffe1fa7285aac002512887d9ce7e0b69dfaed5af3c392fbeee53b9e103725f51R20-R22) [[4]](diffhunk://#diff-7818560383ee4419083e5c6afd9ff63b2af5134db93737aa924454ddd3f4bed6R22-R24) [[5]](diffhunk://#diff-77b6f372655fb8e1bc453344f5364ea37e0776411bfbcd51c05628c0c92ddc87R20-R22) [[6]](diffhunk://#diff-b3c70ce234c0f0620571643a46d9c2e477dc7ee291c2053cb4617d7f76dc2dfcR26-R28) [[7]](diffhunk://#diff-a30e6d4e5af86df8a734297433541839db3db62d515371de1082f192d359ea6cR20-R22) [[8]](diffhunk://#diff-a4e25bdbd0bfba46715c9ced4062e25dbb9ada69283194116d3b705a9ff85403R20-R22) [[9]](diffhunk://#diff-071234d6a937f29b97fcf1628398f8c6ee43a862bed3308b59800f11bfcdc5a1R20-R22) [[10]](diffhunk://#diff-4ee0a593096c54ba0e4681b9ab3cbce17ab196f08749e6b5554fd76948bcc315R24-R26) [[11]](diffhunk://#diff-8f3c11cc9c8a72dbd08f8fc259f0d544bdcc8186018e9babc28790a19708e240R20-R22) [[12]](diffhunk://#diff-e9ea1522a351f8e7dd4102e4edc37e171f5f0c8d0c7adc3a85a682fc598f0ccfR22-R24) [[13]](diffhunk://#diff-290cd9621e54e99c87df9f282133a30b2624154100061a16a52a7938cce668ccR20-R22)

**Device simulation configuration:**

* For the `rbwatcher` robot, the `low_performance_simulation` argument is now passed to key sensor elements (top_lidar, front_camera, top_ptz_camera) as the `low_performance` attribute, allowing these devices to adjust their behavior based on the simulation mode. [[1]](diffhunk://#diff-290cd9621e54e99c87df9f282133a30b2624154100061a16a52a7938cce668ccL44-R48) [[2]](diffhunk://#diff-290cd9621e54e99c87df9f282133a30b2624154100061a16a52a7938cce668ccL56-R61) [[3]](diffhunk://#diff-290cd9621e54e99c87df9f282133a30b2624154100061a16a52a7938cce668ccL67-R73)