### PR TITLE
fix: jazzy/ur simulation dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,13 @@ ros2 launch robotnik_description robot_description.launch.py robot:=rbkairos rob
 ```
 
 Launches the description for the RB-Kairos with a UR arm, under the namespace `robot_b`.
+
+## Repositories Dependencies
+
+- **robotnik_sensors** (branch: `jazzy-devel`)
+
+  Repository with sensors descriptions
+
+- **Universal_Robots_ROS2_Description** (branch: `fix/gazebo-control-jazzy`)
+
+  Robotnik's fork to the official repository with the description of the UR arms and their implementation in Gazebo.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Launches the description for the RB-Kairos with a UR arm, under the namespace `r
 
   Repository with sensors descriptions
 
-- **Universal_Robots_ROS2_Description** (branch: `fix/gazebo-control-jazzy`)
+- **Universal_Robots_ROS2_Description** (branch: `jazzy`)
 
-  Robotnik's fork to the official repository with the description of the UR arms and their implementation in Gazebo.
+  Repository with the description of the UR arms.
+
+- **Universal_Robots_ROS2_GZ_Simulation** (branch: `ros2`)
+
+  URDF with the UR implementation in Gazebo.

--- a/robot_description.repo.yaml
+++ b/robot_description.repo.yaml
@@ -7,5 +7,10 @@ repositories:
   
   src/Universal_Robots_ROS2_Description:
     type: git
-    url: https://github.com/RobotnikAutomation/Universal_Robots_ROS2_Description.git
-    version: fix/gazebo-control-jazzy
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+    version: jazzy
+
+  src/Universal_Robots_ROS2_GZ_Simulation:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
+    version: ros2

--- a/robot_description.repo.yaml
+++ b/robot_description.repo.yaml
@@ -4,3 +4,8 @@ repositories:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_sensors.git
     version: jazzy-devel
+  
+  src/Universal_Robots_ROS2_Description:
+    type: git
+    url: https://github.com/RobotnikAutomation/Universal_Robots_ROS2_Description.git
+    version: fix/gazebo-control-jazzy

--- a/urdf/arms/ur_macro.urdf.xacro
+++ b/urdf/arms/ur_macro.urdf.xacro
@@ -35,23 +35,16 @@
       joint_limits_parameters_file="${joint_limit_params}"
       kinematics_parameters_file="${kinematics_params}"
       physical_parameters_file="${physical_params}"
-      visual_parameters_file="${visual_params}"
-      generate_ros2_control_tag="false">
+      visual_parameters_file="${visual_params}">
       <xacro:insert_block name="origin" />
     </xacro:ur_robot>
 
     <xacro:if value="$(arg gazebo_ignition)">
       <xacro:include
-        filename="$(find ur_description)/urdf/ur.ros2_control.xacro" />
+        filename="$(find ur_simulation_gz)/urdf/ur_gz.ros2_control.xacro" />
       <xacro:ur_ros2_control
-        name="arm"
-        sim_ignition="true"
-        tf_prefix="${frame_prefix}"
-        script_filename=""
-        output_recipe_filename=""
-        input_recipe_filename=""
-        hash_kinematics=""
-        robot_ip="" />
+        name="${frame_prefix}"
+        tf_prefix="${frame_prefix}" />
     </xacro:if>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
This PR is related to #84. The UR official repo does not support (or not well documented) the use of the arms in Gazebo. For this reason we are including as dependency our own fork of the package: https://github.com/RobotnikAutomation/Universal_Robots_ROS2_Description/tree/fix/gazebo-control-jazzy


This pull request adds new repository dependencies required for the robot description package, ensuring all necessary components are included for simulation and sensor support.

Repository dependency updates:

* Updated `robot_description.repo.yaml` to add the `Universal_Robots_ROS2_Description` repository (branch: `fix/gazebo-control-jazzy`) as a dependency, alongside the existing `robotnik_sensors` repository.

Documentation updates:

* Updated the `README.md` file to document the new repository dependencies, providing details about `robotnik_sensors` and `Universal_Robots_ROS2_Description` and their respective branches.