### PR TITLE
Add ur_simulation_gz dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>robotnik_sensors</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur_simulation_gz</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>


### PR DESCRIPTION
## Summary

This PR adds the missing `ur_simulation_gz` dependency to `robotnik_description`.

## Changes

- adds `ur_simulation_gz` as an `exec_depend` in `robotnik_description`

## Why

The UR arm xacro used in simulation references resources from `ur_simulation_gz` when `gazebo_ignition:=true`.

Without this dependency, clean environments may fail to resolve the required simulation resources even though the description package builds correctly.

## Scope

This change only updates the package manifest so dependency resolution works correctly in fresh Jazzy workspaces and Docker-based setups.