### PR TITLE
urdf/rbtheron_body: update charge contactor positions to fix incorrect charge offset

### DIFF
--- a/urdf/bodies/rbtheron/rbtheron_body.urdf.xacro
+++ b/urdf/bodies/rbtheron/rbtheron_body.urdf.xacro
@@ -192,7 +192,7 @@
       name="${prefix}base_docking_joint"
       type="fixed">
       <origin
-        xyz="0.35 0 0.09"
+        xyz="0.32 0 0.09"
         rpy="0 0 0" />
       <parent link="${prefix}base_link" />
       <child link="${prefix}base_docking_contact" />


### PR DESCRIPTION
When rbtheron moves to the charging station using robotnik_charge, an offset is observed between the robot and the charging contactors due to an incorrect contactor position defined in the URDF. This offset causes the charging process to fail.